### PR TITLE
refactor of sendwidget -> sendJup to APIRouterProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Transactions from "views/Transactions";
 
 // Hooks
 import useAuth from "hooks/useAuth";
+import { APIRouterProvider } from "./contexts/APIRouterContext";
 
 /*
  * https://github.com/jupiter-project/logos
@@ -157,7 +158,9 @@ const MUIThemeProvider: React.FC = ({ children }) => {
       <APIProvider>
         <BlockProvider>
           <AccountProvider>
-            <MyTxProvider>{children}</MyTxProvider>
+            <MyTxProvider>
+              <APIRouterProvider>{children}</APIRouterProvider>
+            </MyTxProvider>
           </AccountProvider>
         </BlockProvider>
       </APIProvider>

--- a/src/contexts/APIContext/Provider.tsx
+++ b/src/contexts/APIContext/Provider.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import Context from "./Context";
 import { IGetAccountResult, IUnsignedTransaction } from "types/NXTAPI";
 import getAccount from "utils/api/getAccount";
-import sendJUP from "utils/api/sendJUP";
 import getAccountId from "utils/api/getAccountId";
 import getBlockchainStatus from "utils/api/getBlockchainStatus";
 import getBalance from "utils/api/getBalance";
@@ -11,6 +10,25 @@ import setAccountInfo from "utils/api/setAccountInfo";
 import getBlocks from "utils/api/getBlocks";
 
 const APIProvider: React.FC = ({ children }) => {
+  const handleFetchAccountIDFromRS = useCallback(async (address: string): Promise<string | undefined> => {
+    if (getAccount === undefined || getAccountId === undefined) {
+      return;
+    }
+
+    try {
+      const result = await getAccount(address);
+      if (result) {
+        const accountResult = await getAccountId(result.publicKey);
+        if (accountResult) {
+          return accountResult.account;
+        }
+      }
+    } catch (e) {
+      console.error("error while fetching public key:", e);
+      return;
+    }
+  }, []);
+
   const handleGetAccount = useCallback(async (address: string) => {
     let account: IGetAccountResult;
 
@@ -21,10 +39,6 @@ const APIProvider: React.FC = ({ children }) => {
       return false;
     }
     return account;
-  }, []);
-
-  const handleSendJUP = useCallback(async (unsignedTxJSON: IUnsignedTransaction) => {
-    return sendJUP(unsignedTxJSON); // return the result back to the caller so they can work with the whole signed object/error for now
   }, []);
 
   const handleGetBlockchainTransactions = useCallback(async (account: string) => {
@@ -59,9 +73,9 @@ const APIProvider: React.FC = ({ children }) => {
         setAccountInfo,
         getAccountId,
         getBalance,
-        sendJUP: handleSendJUP,
         getMyTxs: handleGetBlockchainTransactions,
         getBlocks: handleGetBlocks,
+        handleFetchAccountIDFromRS,
       }}
     >
       {children}

--- a/src/contexts/APIContext/types.ts
+++ b/src/contexts/APIContext/types.ts
@@ -14,7 +14,8 @@ export interface ContextValues {
   setAccountInfo?: (secret: string, accountName: string, accountDescr: string) => Promise<any>;
   getAccountId?: (publicKey: string) => Promise<false | IGetAccountIdResult>;
   getBalance?: (account: string) => Promise<false | IGetBalanceResult>;
-  sendJUP?: (unsignedTxJSON: IUnsignedTransaction) => Promise<boolean>;
   getMyTxs?: (account: string) => Promise<false | IGetBlockchainTransactionResult>;
   getBlocks?: (firstIndex: number, lastIndex: number) => Promise<false | IGetBlocksResult>;
+
+  handleFetchAccountIDFromRS?: (address: string) => Promise<string | undefined>;
 }

--- a/src/contexts/APIRouterContext/Context.ts
+++ b/src/contexts/APIRouterContext/Context.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+import { ContextValues } from "./types";
+
+const Context = createContext<ContextValues>({});
+
+export default Context;

--- a/src/contexts/APIRouterContext/Provider.tsx
+++ b/src/contexts/APIRouterContext/Provider.tsx
@@ -1,0 +1,142 @@
+import React, { useCallback, useRef, useState } from "react";
+import Context from "./Context";
+import sendJUP from "utils/api/sendJUP";
+import { IGetAccountResult, IUnsignedTransaction } from "types/NXTAPI";
+import useAccount from "hooks/useAccount";
+import { isValidAddress } from "utils/validation";
+import useAPI from "hooks/useAPI";
+import { JUPGenesisTimestamp, standardDeadline, standardFee } from "utils/common/constants";
+import { useSnackbar } from "notistack";
+import { messageText } from "../../utils/common/messages";
+import { DialogContent, Box, Typography, Stack, styled, Input, Button } from "@mui/material";
+import JUPDialog from "../../components/JUPDialog";
+
+const APIRouterProvider: React.FC = ({ children }) => {
+  const { accountRs, publicKey } = useAccount();
+  const { handleFetchAccountIDFromRS } = useAPI();
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+  const [requestUserSecret, setRequestUserSecret] = useState<boolean>(false);
+  const [userSecretInput, setUserSecretInput] = useState<string>("");
+  const afterSecretCB = useRef<(secretPhrase: string) => Promise<void> | undefined>();
+
+  const _handleSendJUP = useCallback(
+    async (tx: IUnsignedTransaction, secretPhrase: string) => {
+      tx.secretPhrase = secretPhrase;
+
+      const result = await sendJUP(tx);
+
+      console.log("send result:", result);
+
+      if (!result) {
+        enqueueSnackbar(messageText.transaction.failure, { variant: "error" });
+        return;
+      }
+
+      enqueueSnackbar(messageText.transaction.success, { variant: "success" });
+    },
+    [enqueueSnackbar]
+  );
+
+  const handleSendJUP = useCallback(
+    async (toAddress: string, amount: string): Promise<true | undefined> => {
+      // TODO: validate amount at the input layer, or here or somewhere smort
+
+      if (accountRs === undefined || handleFetchAccountIDFromRS === undefined) {
+        // TODO: error reporting this properly
+        return;
+      }
+
+      // make sure address is valid
+      if (!isValidAddress(toAddress)) {
+        return;
+      }
+
+      const recipientAccountId = await handleFetchAccountIDFromRS(toAddress);
+      const tx: IUnsignedTransaction = {
+        senderPublicKey: publicKey, // publicKey from useAccount() hook
+        senderRS: accountRs, // accountRs from useAccount() hook
+        // sender: "123", // required in some situations?
+        feeNQT: standardFee,
+        version: 1,
+        phased: false,
+        type: 0,
+        subtype: 0,
+        attachment: { "version.OrdinaryPayment": 0 },
+        amountNQT: amount, // TODO: use converter function, but for now it's nice for cheaper testing
+        recipientRS: toAddress,
+        recipient: recipientAccountId,
+        ecBlockHeight: 0, // must be included
+        deadline: standardDeadline,
+        timestamp: Math.round(Date.now() / 1000) - JUPGenesisTimestamp, // Seconds since Genesis. sets the origination time of the tx (since broadcast can happen later).
+        secretPhrase: "",
+      };
+
+      afterSecretCB.current = _handleSendJUP.bind(null, tx);
+      setRequestUserSecret(true);
+
+      return true;
+    },
+    [_handleSendJUP, accountRs, handleFetchAccountIDFromRS, publicKey]
+  );
+
+  const handleSecretEntry = useCallback((secretInput) => {
+    setUserSecretInput(secretInput);
+  }, []);
+
+  const handleCloseSeedCollection = useCallback(() => {
+    setRequestUserSecret(false);
+    setUserSecretInput("");
+    afterSecretCB.current = undefined;
+    enqueueSnackbar(messageText.transaction.cancel, { variant: "warning" });
+  }, [enqueueSnackbar]);
+
+  const handleSubmitSecret = useCallback(async () => {
+    try {
+      if (afterSecretCB.current !== undefined) {
+        await afterSecretCB.current(userSecretInput);
+      }
+    } catch (e) {
+      console.error("failed to execute api call after confirm & send", e);
+    }
+
+    afterSecretCB.current = undefined;
+    setUserSecretInput("");
+    handleCloseSeedCollection();
+  }, [handleCloseSeedCollection, userSecretInput]);
+
+  return (
+    <Context.Provider
+      value={{
+        sendJUP: handleSendJUP,
+      }}
+    >
+      {children}
+      {/* dialog handles obtaining secret phrase if needed by the current action */}
+      <JUPDialog isOpen={requestUserSecret} closeFn={handleCloseSeedCollection}>
+        <DialogContent>
+          <Box sx={{ minWidth: "600px", height: "300px" }}>
+            <Typography align="center">Please enter your seed phrase.</Typography>
+            <Stack sx={{ alignItems: "center" }}>
+              <SeedphraseEntryBox onChange={(e) => handleSecretEntry(e.target.value)} type="password" placeholder="Enter Seed Phrase" />
+              <ConfirmButton variant="contained" onClick={() => handleSubmitSecret()}>
+                Confirm & Send
+              </ConfirmButton>
+            </Stack>
+          </Box>
+        </DialogContent>
+      </JUPDialog>
+    </Context.Provider>
+  );
+};
+
+const SeedphraseEntryBox = styled(Input)(({ theme }) => ({
+  minWidth: "400px",
+  margin: "40px 0px",
+}));
+
+const ConfirmButton = styled(Button)(({ theme }) => ({
+  margin: "20px 0px",
+}));
+
+export default APIRouterProvider;

--- a/src/contexts/APIRouterContext/Provider.tsx
+++ b/src/contexts/APIRouterContext/Provider.tsx
@@ -116,7 +116,7 @@ const APIRouterProvider: React.FC = ({ children }) => {
     afterSecretCB.current = undefined;
     setUserSecretInput("");
 
-    // close seed collection dialog without firing the closeFn
+    // close seed collection dialog without firing the closeFn (prevents a duplicate notification)
     setRequestUserSecret(false);
   }, [userSecretInput]);
 

--- a/src/contexts/APIRouterContext/Provider.tsx
+++ b/src/contexts/APIRouterContext/Provider.tsx
@@ -81,7 +81,7 @@ const APIRouterProvider: React.FC = ({ children }) => {
     [_handleSendJUP, accountRs, handleFetchAccountIDFromRS, publicKey]
   );
 
-  const handleSecretEntry = useCallback((secretInput) => {
+  const handleSecretEntry = useCallback((secretInput: string) => {
     setUserSecretInput(secretInput);
   }, []);
 
@@ -102,9 +102,11 @@ const APIRouterProvider: React.FC = ({ children }) => {
   const handleSubmitSecret = useCallback(async () => {
     let result;
     try {
-      if (afterSecretCB.current !== undefined) {
-        result = await afterSecretCB.current(userSecretInput);
+      if (afterSecretCB.current === undefined) {
+        throw new Error(`handleSubmitSecret afterSecretCB.current is undefined: ${afterSecretCB.current}`);
       }
+
+      result = await afterSecretCB.current(userSecretInput);
     } catch (e) {
       console.error("failed to execute api call after confirm & send", e);
     }
@@ -130,7 +132,7 @@ const APIRouterProvider: React.FC = ({ children }) => {
       {/* dialog handles obtaining secret phrase if needed by the current action */}
       <JUPDialog isOpen={requestUserSecret} closeFn={() => handleCloseSeedCollection(false)}>
         <DialogContent>
-          <Box sx={{ minWidth: "600px", height: "300px" }}>
+          <Box>
             <Typography align="center">Please enter your seed phrase.</Typography>
             <Stack sx={{ alignItems: "center" }}>
               <SeedphraseEntryBox onChange={(e) => handleSecretEntry(e.target.value)} type="password" placeholder="Enter Seed Phrase" />

--- a/src/contexts/APIRouterContext/index.ts
+++ b/src/contexts/APIRouterContext/index.ts
@@ -1,0 +1,4 @@
+export { default as APIRouterContext } from "./Context";
+export { default as APIRouterProvider } from "./Provider";
+
+export type { ContextValues as APIRouterContextValues } from "./types";

--- a/src/contexts/APIRouterContext/types.ts
+++ b/src/contexts/APIRouterContext/types.ts
@@ -1,0 +1,3 @@
+export interface ContextValues {
+  sendJUP?: (toAddress: string, amount: string) => Promise<true | undefined>;
+}

--- a/src/hooks/useAPIRouter.ts
+++ b/src/hooks/useAPIRouter.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { APIRouterContext } from "../contexts/APIRouterContext";
+
+const useAPIRouter = () => ({
+  ...useContext(APIRouterContext),
+});
+
+export default useAPIRouter;

--- a/src/views/Dashboard/components/Widgets/SendWidget/SendWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/SendWidget/SendWidget.tsx
@@ -1,14 +1,10 @@
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { Autocomplete, Box, Button, DialogContent, Grid, Input, Stack, styled, Typography } from "@mui/material";
 import TextField from "@mui/material/TextField";
-import { IUnsignedTransaction } from "types/NXTAPI";
-import { isValidAddress } from "utils/validation";
 import { messageText } from "utils/common/messages";
-import useAccount from "hooks/useAccount";
-import useAPI from "hooks/useAPI";
-import { JUPGenesisTimestamp, standardDeadline, standardFee } from "utils/common/constants";
 import JUPDialog from "components/JUPDialog";
 import { useSnackbar } from "notistack";
+import useAPIRouter from "hooks/useAPIRouter";
 
 // [x]: Pagination
 // MUST: Improve styling
@@ -19,92 +15,17 @@ const placeHolderVals = ["JUP", "ASTRO"];
 const SendWidget: React.FC = () => {
   const [toAddress, setToAddress] = useState<string>("");
   const [sendQuantity, setSendQuantity] = useState<string>();
-  const [requestUserSecret, setRequestUserSecret] = useState<boolean>(false);
-  const [userSecretInput, setUserSecretInput] = useState<string>("");
-  const { accountRs, publicKey } = useAccount();
-  const { sendJUP, getAccount, getAccountId } = useAPI();
-  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
-
-  const handleCloseSeedCollection = useCallback(() => {
-    setRequestUserSecret(false);
-    enqueueSnackbar(messageText.transaction.cancel, { variant: "warning" });
-  }, [enqueueSnackbar]);
-
-  const fetchRecipAccountId = useCallback(async () => {
-    if (getAccount !== undefined && getAccountId !== undefined) {
-      try {
-        const result = await getAccount(toAddress);
-        if (result) {
-          const accountResult = await getAccountId(result.publicKey);
-          if (accountResult) {
-            return accountResult.account;
-          }
-        }
-      } catch (e) {
-        console.error("error while fetching public key:", e);
-        return;
-      }
-    }
-  }, [getAccount, getAccountId, toAddress]);
-
-  // need a final useEffect which gets run when all other pieces are ready to build the transaction
-  const prepareUnsignedTx = useCallback(
-    async (secret: string): Promise<IUnsignedTransaction | undefined> => {
-      // make sure address is valid
-      if (!isValidAddress(toAddress)) {
-        return;
-      }
-
-      if (accountRs === undefined || sendQuantity === undefined) {
-        return;
-      }
-
-      const recipientAccountId = await fetchRecipAccountId();
-      const tx: IUnsignedTransaction = {
-        senderPublicKey: publicKey, // publicKey from useAccount() hook
-        senderRS: accountRs, // accountRs from useAccount() hook
-        // sender: "123", // required in some situations?
-        feeNQT: standardFee,
-        version: 1,
-        phased: false,
-        type: 0,
-        subtype: 0,
-        attachment: { "version.OrdinaryPayment": 0 },
-        amountNQT: sendQuantity, // TODO: use converter function, but for now it's nice for cheaper testing
-        recipientRS: toAddress,
-        recipient: recipientAccountId,
-        ecBlockHeight: 0, // must be included
-        deadline: standardDeadline,
-        timestamp: Math.round(Date.now() / 1000) - JUPGenesisTimestamp, // Seconds since Genesis. sets the origination time of the tx (since broadcast can happen later).
-        secretPhrase: secret,
-      };
-
-      return tx;
-    },
-    [accountRs, fetchRecipAccountId, publicKey, sendQuantity, toAddress]
-  );
+  const { sendJUP } = useAPIRouter();
 
   const handleSend = useCallback(async () => {
-    if (sendJUP !== undefined) {
-      setRequestUserSecret(true);
+    if (sendJUP === undefined || sendQuantity === undefined || toAddress === "") {
+      return;
     }
-  }, [sendJUP]);
 
-  const handleSubmitSecret = useCallback(
-    async (secret: string) => {
-      const unsignedTx = await prepareUnsignedTx(secret);
-      if (sendJUP !== undefined && unsignedTx !== undefined) {
-        const result = await sendJUP(unsignedTx);
-        if (result) {
-          enqueueSnackbar(messageText.transaction.success, { variant: "success" });
-          return;
-        }
-        enqueueSnackbar(messageText.transaction.failure, { variant: "error" });
-        console.log("send result:", result);
-      }
-    },
-    [enqueueSnackbar, prepareUnsignedTx, sendJUP]
-  );
+    const result = await sendJUP(toAddress, sendQuantity);
+
+    console.log("sendWidget sendJUP result:", result);
+  }, [sendJUP, sendQuantity, toAddress]);
 
   const handleToAddressEntry = useCallback(
     (toAddressInput: string) => {
@@ -117,55 +38,26 @@ const SendWidget: React.FC = () => {
     setSendQuantity(quantityInput);
   }, []);
 
-  const handleSecretEntry = useCallback((secretInput) => {
-    setUserSecretInput(secretInput);
-  }, []);
-
-  const ConditionalSendWidget = useMemo(() => {
-    return (
-      requestUserSecret && (
-        <>
-          <JUPDialog isOpen={requestUserSecret} closeFn={handleCloseSeedCollection}>
-            <DialogContent>
-              <Box sx={{ minWidth: "600px", height: "300px" }}>
-                <Typography align="center">Please enter your seed phrase.</Typography>
-                <Stack sx={{ alignItems: "center" }}>
-                  <SeedphraseEntryBox onChange={(e) => handleSecretEntry(e.target.value)} type="password" placeholder="Enter Seed Phrase" />
-                  <ConfirmButton variant="contained" onClick={() => handleSubmitSecret(userSecretInput)}>
-                    Confirm & Send
-                  </ConfirmButton>
-                </Stack>
-              </Box>
-            </DialogContent>
-          </JUPDialog>
-        </>
-      )
-    );
-  }, [handleCloseSeedCollection, handleSecretEntry, handleSubmitSecret, requestUserSecret, userSecretInput]);
-
   return (
     <>
-      {ConditionalSendWidget}
-      <>
-        <StyledWidgetHeading>Send JUP</StyledWidgetHeading>
+      <StyledWidgetHeading>Send JUP</StyledWidgetHeading>
 
-        <Grid container>
-          <Grid item xs={10}>
-            <StyledAutocomplete
-              freeSolo
-              options={placeHolderVals.map((option) => option)}
-              renderInput={(params) => <TextField {...params} label="Enter asset name" />}
-            />
-            <StyledToAddressInput onChange={(e) => handleToAddressEntry(e.target.value)} placeholder="To Address" />
-            <StyledQuantityInput onChange={(e) => handleQuantityEntry(e.target.value)} placeholder="Quantity" />
-          </Grid>
-          <Grid item xs={2}>
-            <StyledSendButton fullWidth onClick={handleSend} variant="contained">
-              Send
-            </StyledSendButton>
-          </Grid>
+      <Grid container>
+        <Grid item xs={10}>
+          <StyledAutocomplete
+            freeSolo
+            options={placeHolderVals.map((option) => option)}
+            renderInput={(params) => <TextField {...params} label="Enter asset name" />}
+          />
+          <StyledToAddressInput onChange={(e) => handleToAddressEntry(e.target.value)} placeholder="To Address" />
+          <StyledQuantityInput onChange={(e) => handleQuantityEntry(e.target.value)} placeholder="Quantity" />
         </Grid>
-      </>
+        <Grid item xs={2}>
+          <StyledSendButton fullWidth onClick={handleSend} variant="contained">
+            Send
+          </StyledSendButton>
+        </Grid>
+      </Grid>
     </>
   );
 };


### PR DESCRIPTION
send widget refactoring api calls to another provider layer

Co-authored-by: Nathan Bowers <outragedhuman@users.noreply.github.com>