### PR TITLE
Update setUserInfo to Use useAPIRouter() Hook

### DIFF
--- a/src/contexts/APIContext/Provider.tsx
+++ b/src/contexts/APIContext/Provider.tsx
@@ -130,7 +130,6 @@ const APIProvider: React.FC = ({ children }) => {
       value={{
         getBlockchainStatus,
         getAccount: handleGetAccount,
-        setAccountInfo,
         getAccountId,
         getBalance,
         getMyTxs: handleGetBlockchainTransactions,

--- a/src/contexts/APIContext/types.ts
+++ b/src/contexts/APIContext/types.ts
@@ -14,7 +14,6 @@ import {
 export interface ContextValues {
   getBlockchainStatus?: () => Promise<false | IGetBlockchainStatusResult>;
   getAccount?: (account: string) => Promise<false | IGetAccountResult>;
-  setAccountInfo?: (secret: string, accountName: string, accountDescr: string) => Promise<any>;
   getAccountId?: (publicKey: string) => Promise<false | IGetAccountIdResult>;
   getBalance?: (account: string) => Promise<false | IGetBalanceResult>;
   getMyTxs?: (account: string) => Promise<false | IGetBlockchainTransactionResult>;

--- a/src/contexts/APIRouterContext/Provider.tsx
+++ b/src/contexts/APIRouterContext/Provider.tsx
@@ -194,7 +194,6 @@ const APIRouterProvider: React.FC = ({ children }) => {
 
       try {
         result = await setAccountInfo(tx);
-        console.log("set account info result:", result);
       } catch (e) {
         console.error("error while setting account info:", e);
         return;

--- a/src/contexts/APIRouterContext/types.ts
+++ b/src/contexts/APIRouterContext/types.ts
@@ -4,4 +4,5 @@ export interface ContextValues {
   sendJUP?: (toAddress: string, amount: string) => Promise<true | undefined>;
   sendAsset?: (toAddress: string, amount: string, assetId: string) => Promise<true | undefined>;
   placeOrder?: (orderType: "bid" | "ask", assetID: number, quantityQNT: BigNumber, priceNQT: BigNumber) => Promise<true | undefined>;
+  setAccountInfo?: (userName: string, description: string) => Promise<true | undefined>;
 }

--- a/src/types/NXTAPI/index.ts
+++ b/src/types/NXTAPI/index.ts
@@ -196,6 +196,12 @@ export interface IPlaceOrderResult extends IBaseAPIResult {
   tbd: string;
 }
 
+export interface ISetAccountInfo {
+  name: string;
+  description: string;
+  secretPhrase: string;
+}
+
 //
 // Not used yet, move to the section above as these are used
 //

--- a/src/utils/api/setAccountInfo.ts
+++ b/src/utils/api/setAccountInfo.ts
@@ -25,7 +25,7 @@ interface ISetAccountInfoPayload extends IAPICall {
   };
 }
 
-async function setAccountInfo(secret: string, accountName: string, accountDescr: string) {
+async function setAccountInfo({ ...args }) {
   let result;
 
   const options: ISetAccountInfoPayload = {
@@ -33,9 +33,12 @@ async function setAccountInfo(secret: string, accountName: string, accountDescr:
     method: "POST",
     requestType: "setAccountInfo",
     data: {
-      secretPhrase: secret,
-      name: accountName,
-      description: accountDescr,
+      // args
+      secretPhrase: args.secretPhrase,
+      name: args.name,
+      description: args.description,
+
+      // standards
       feeNQT: standardFee,
       deadline: standardDeadline,
     },


### PR DESCRIPTION
Updates the setUserInfo to utilize the useAPIRouter() hook. 

After implementing this I realized I don't need any of the other hook values (like accountRS or publicKey) to use this endpoint so it may not make sense to do it this way, and it may be better to use the useAPI() hook. 

For consistency it might be better to have all private methods use the router hook, however...

Unable to test this because for some reason the testnet node reverts any setUserInfo() calls (even using the existing wallet UI). 

EDIT: Manually tested fine on production node.

EDIT 2: After reviewing again it makes sense to use the router because it moves the secret phrase collection layer to the APIrouter hook which cleans up the widget code significantly.