### PR TITLE
Change Buy/Sell Buttons to be in a ButtonGroup

### DIFF
--- a/src/views/Dashboard/components/Widgets/DEXWidget/DEXWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/DEXWidget/DEXWidget.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Button, ButtonGroup, Divider, Grid, Stack, styled, Typography } from "@mui/material";
+import { Box, Button, ButtonGroup, Divider, Grid, Stack, styled, Typography } from "@mui/material";
 import { BigNumber } from "bignumber.js";
 import JUPAssetSearchBox from "components/JUPAssetSearchBox";
 import JUPInput from "components/JUPInput";
@@ -127,7 +127,7 @@ const DEXWidget: React.FC = () => {
 
       <Grid container>
         <Grid item xs={10}>
-          <Stack sx={{ width: "95%", margin: "0px 10px", padding: "10px" }}>
+          <Stack sx={{ width: "95%", margin: "0px 10px", padding: "10px" }} spacing={2}>
             <JUPAssetSearchBox fetchFn={(asset: number) => handleFetchSelectedAsset(asset)} />
             <StyledPriceInput inputType="price" fetchFn={(price) => handleFetchPrice(price)} placeholder="Price" />
             <StyledQuantityInput inputType="quantity" fetchFn={(quantity) => handleFetchQuantity(quantity)} placeholder="Quantity" />

--- a/src/views/Dashboard/components/Widgets/DEXWidget/DEXWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/DEXWidget/DEXWidget.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Divider, Grid, Stack, styled, Typography } from "@mui/material";
+import { Button, ButtonGroup, Divider, Grid, Stack, styled, Typography } from "@mui/material";
 import { BigNumber } from "bignumber.js";
 import JUPAssetSearchBox from "components/JUPAssetSearchBox";
 import JUPInput from "components/JUPInput";
@@ -136,12 +136,14 @@ const DEXWidget: React.FC = () => {
           </Stack>
         </Grid>
         <Grid item xs={2}>
-          <StyledSwapButton fullWidth onClick={() => handleSwap("buy")} variant="green">
-            Buy
-          </StyledSwapButton>
-          <StyledSwapButton fullWidth onClick={() => handleSwap("sell")} variant="red">
-            Sell
-          </StyledSwapButton>
+          <ButtonGroup orientation="vertical" sx={{ height: "100%" }}>
+            <StyledSwapButton fullWidth onClick={() => handleSwap("buy")} variant="green">
+              Buy
+            </StyledSwapButton>
+            <StyledSwapButton fullWidth onClick={() => handleSwap("sell")} variant="red">
+              Sell
+            </StyledSwapButton>
+          </ButtonGroup>
         </Grid>
       </Grid>
     </>

--- a/src/views/Dashboard/components/Widgets/SendWidget/SendWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/SendWidget/SendWidget.tsx
@@ -55,7 +55,7 @@ const SendWidget: React.FC = () => {
 
       <Grid container>
         <Grid item xs={12}>
-          <Stack sx={{ width: "95%", margin: "10px", padding: "10px" }}>
+          <Stack sx={{ width: "95%", margin: "10px", padding: "10px" }} spacing={2}>
             {/* removing search box for now, will eventually extend this widget to allow asset transfers */}
             {/* <JUPAssetSearchBox fetchFn={handleFetch} /> */}
             <StyledToAddressInput


### PR DESCRIPTION
Original buttons were just two regular `Button` components smashed together. This changes them to be a `ButtonGroup` which looks a bit better. 

I ran the dex widget tests and it looks okay, but the node is broken again so it wasn't working right. Manual testing shows the new group works as expected.