### PR TITLE
Transactions Full Page App

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Jovian is the term that encompasses all things "Jupiter". It is the adjective fo
         <td>Portfolio Page</td>
         <td>2 weeks</td>
         <td>August 31</td>
-        <td>-</td>
+        <td>August 31</td>
     </tr>
         <tr>
         <td>Transactions</td>

--- a/src/components/JUPTable/JUPTable.tsx
+++ b/src/components/JUPTable/JUPTable.tsx
@@ -17,7 +17,7 @@ import {
 import { TransitionGroup } from "react-transition-group";
 import SLink from "components/SLink";
 import { visuallyHidden } from "@mui/utils";
-import { DefaultTableRowsPerPage, DefaultTransitionTime, TableRowsPerPageOptions } from "utils/common/constants";
+import { DefaultLongTableRowsPerPage, DefaultShortTableRowsPerPage, DefaultTransitionTime, TableRowsPerPageOptions } from "utils/common/constants";
 import { IHeadCellProps, ITableRow } from ".";
 
 interface ITableTitleProps {
@@ -103,12 +103,25 @@ interface IJUPTableProps {
   path?: string;
   DisplayedComponents?: Array<React.ReactElement>;
   defaultSortOrder?: Order;
+  rowsPerPageStyle?: "short" | "long"; // determines which page row quantity options are presented to the user
   isPaginated?: boolean;
   keyProp: string; // This prop gets used to build a unique key
 }
 
-const JUPTable: React.FC<IJUPTableProps> = ({ headCells, rows, title, path, DisplayedComponents, defaultSortOrder, isPaginated, keyProp }) => {
-  const [rowsPerPage, setRowsPerPage] = useState(DefaultTableRowsPerPage);
+const JUPTable: React.FC<IJUPTableProps> = ({
+  headCells,
+  rows,
+  title,
+  path,
+  DisplayedComponents,
+  defaultSortOrder,
+  rowsPerPageStyle,
+  isPaginated,
+  keyProp,
+}) => {
+  const [rowsPerPage, setRowsPerPage] = useState(
+    rowsPerPageStyle === "short" || rowsPerPageStyle === undefined ? DefaultShortTableRowsPerPage : DefaultLongTableRowsPerPage
+  );
   const [order, setOrder] = useState<Order>("desc");
   const [orderBy, setOrderBy] = useState<string>("");
   const [page, setPage] = useState(0);
@@ -220,7 +233,9 @@ const JUPTable: React.FC<IJUPTableProps> = ({ headCells, rows, title, path, Disp
   const PaginationMemo = useMemo(() => {
     return isPaginated ? (
       <TablePagination
-        rowsPerPageOptions={TableRowsPerPageOptions}
+        rowsPerPageOptions={
+          rowsPerPageStyle === "short" || rowsPerPageStyle === undefined ? TableRowsPerPageOptions.short : TableRowsPerPageOptions.long
+        }
         component="div"
         count={rows?.length || 0}
         rowsPerPage={rowsPerPage}
@@ -231,7 +246,7 @@ const JUPTable: React.FC<IJUPTableProps> = ({ headCells, rows, title, path, Disp
     ) : (
       <></>
     );
-  }, [handleChangePage, handleChangeRowsPerPage, isPaginated, page, rows?.length, rowsPerPage]);
+  }, [handleChangePage, handleChangeRowsPerPage, isPaginated, page, rows?.length, rowsPerPage, rowsPerPageStyle]);
 
   return (
     <TableBackground id={`${title?.toLowerCase().split(" ").join("_")}`}>

--- a/src/components/JUPTable/JUPTable.tsx
+++ b/src/components/JUPTable/JUPTable.tsx
@@ -72,7 +72,7 @@ const EnhancedTableHead: React.FC<IEnhancedTableProps> = ({ onRequestSort, order
 
   const HeadCellsMemo = useMemo(() => {
     return headCells?.map((headCell) => (
-      <TableCell key={headCell.id} align={headCell.headAlignment} padding={"normal"} sortDirection={orderBy === headCell.id ? order : false}>
+      <TableCell key={headCell.id} align={headCell.headAlignment} padding={"none"} sortDirection={orderBy === headCell.id ? order : false}>
         <TableSortLabel
           active={orderBy === headCell.id}
           direction={orderBy === headCell.id ? order : "asc"}
@@ -237,7 +237,7 @@ const JUPTable: React.FC<IJUPTableProps> = ({ headCells, rows, title, path, Disp
     <TableBackground id={`${title?.toLowerCase().split(" ").join("_")}`}>
       <TableContainer>
         <TableTitle title={title} path={path} DisplayedComponents={DisplayedComponents} />
-        <Table aria-labelledby="tableTitle" size={"small"}>
+        <Table aria-labelledby="tableTitle" size={"small"} padding="normal">
           <EnhancedTableHead headCells={headCells} order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
           <TableBody>
             {RowDataMemo}

--- a/src/components/JUPTable/JUPTable.tsx
+++ b/src/components/JUPTable/JUPTable.tsx
@@ -77,6 +77,7 @@ const EnhancedTableHead: React.FC<IEnhancedTableProps> = ({ onRequestSort, order
           active={orderBy === headCell.id}
           direction={orderBy === headCell.id ? order : "asc"}
           onClick={(e) => createSortHandler(e, headCell.id)}
+          hideSortIcon={true}
         >
           {headCell.label}
           {orderBy === headCell.id ? (

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { styled } from "@mui/material/styles";
 
-const Page: React.FC = ({ children }) => (
-  <>
-    <StyledMain>{children}</StyledMain>
-  </>
-);
+const Page: React.FC = ({ children }) => {
+  return (
+    <>
+      <StyledMain>{children}</StyledMain>
+    </>
+  );
+};
 const StyledMain = styled("div")(({ theme }) => ({
   alignItems: "center",
   boxSizing: "border-box",

--- a/src/utils/common/constants.ts
+++ b/src/utils/common/constants.ts
@@ -26,8 +26,9 @@ export const PrecisionExponent = 8; // Used for conversion of NXT->NQT values
 export const MaximumSupply = 1000000000; // Maximum JUP supply in human readable units
 
 //  Table stuff
-export const TableRowsPerPageOptions = [3, 5]; // Which row count options should be displayed in tables
-export const DefaultTableRowsPerPage = TableRowsPerPageOptions[0]; // default to the first option in the list of options
+export const TableRowsPerPageOptions = { short: [3, 5], long: [10, 25, 50, 100] }; // Which row count options should be displayed in tables
+export const DefaultShortTableRowsPerPage = TableRowsPerPageOptions.short[0]; // default to the first option in the list of short options
+export const DefaultLongTableRowsPerPage = TableRowsPerPageOptions.long[0]; // default to the first option in the list of long options
 export const DefaultTransitionTime = 500; // Controls animation transition time for tables
 
 // Block fetching stuff

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -4,66 +4,17 @@ import WidgetContainer from "views/Dashboard/components/WidgetContainer";
 import Page from "components/Page";
 import Drawer from "../../components/Drawer";
 import JUPAppBar from "components/JUPAppBar";
-import JUPTable, { IHeadCellProps, ITableRow } from "components/JUPTable";
+import JUPTable, { ITableRow } from "components/JUPTable";
 import JUPDialog from "components/JUPDialog";
+import { ITransaction } from "types/NXTAPI";
 import { LongUnitPrecision } from "utils/common/constants";
 import { TimestampToDate } from "utils/common/Formatters";
 import { NQTtoNXT } from "utils/common/NQTtoNXT";
 import useMyTxs from "hooks/useMyTxs";
 import useBreakpoint from "hooks/useBreakpoint";
 import { BigNumber } from "bignumber.js";
-import { ITransaction } from "types/NXTAPI";
-
-const txOverviewHeaders: Array<IHeadCellProps> = [
-  {
-    id: "date_ui",
-    label: "Date",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-  {
-    id: "qty",
-    label: "Qty",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-  {
-    id: "fee",
-    label: "Fee",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-  {
-    id: "from",
-    label: "From",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-  {
-    id: "to",
-    label: "To",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-  {
-    id: "height",
-    label: "Height",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-  {
-    id: "confirmations",
-    label: "Confirmations",
-    headAlignment: "center",
-    rowAlignment: "center",
-  },
-];
-
-interface ITxDetail {
-  hash: string;
-  headers: Array<IHeadCellProps>;
-  rows: Array<ITableRow>;
-}
+import { detailedTxColumns, ITxDetail } from "./constants/detailedTxColumns";
+import { txOverviewHeaders } from "./constants/txOverviewHeaders";
 
 const Transactions: React.FC = () => {
   const [drawerIsOpen, setDrawerIsOpen] = useState<boolean>(true);
@@ -81,34 +32,12 @@ const Transactions: React.FC = () => {
     (hash: string) => {
       const tx = transactions?.filter((transaction) => transaction.fullHash === hash)[0];
 
+      if (!tx) {
+        console.error("No detailed tx to open...");
+        return;
+      }
       setIsOpenTxDetail(true);
-      setTxDetail({
-        hash,
-        headers: [
-          {
-            id: "col1",
-            label: "Name",
-            headAlignment: "center",
-            rowAlignment: "center",
-          },
-          {
-            id: "col2",
-            label: "Details",
-            headAlignment: "center",
-            rowAlignment: "center",
-          },
-        ],
-        rows: [
-          {
-            col1: "Hash",
-            col2: hash,
-          },
-          {
-            col1: "Timestamp",
-            col2: tx?.timestamp,
-          },
-        ],
-      } as ITxDetail);
+      setTxDetail(detailedTxColumns(tx));
     },
     [transactions]
   );
@@ -152,7 +81,7 @@ const Transactions: React.FC = () => {
       <JUPAppBar toggleFn={handleDrawerToggle} isSidebarExpanded={drawerIsOpen} />
       <WidgetContainer isSidebarExpanded={drawerIsOpen}>
         {/* Dialog for block details */}
-        <JUPDialog title={`Detailed overview for transaction: ${txDetail?.hash}`} isOpen={isOpenTxDetail} closeFn={handleCloseDialog}>
+        <JUPDialog title={`Detailed overview for transaction: ${txDetail?.txId}`} isOpen={isOpenTxDetail} closeFn={handleCloseDialog}>
           <JUPTable keyProp={"col1"} headCells={txDetail?.headers} rows={txDetail?.rows} defaultSortOrder={"asc"} isPaginated={false}></JUPTable>
         </JUPDialog>
 

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -1,16 +1,38 @@
-import React, { memo } from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import { Typography } from "@mui/material";
 import Page from "components/Page";
 import Drawer from "../../components/Drawer";
 import SearchBar from "components/SearchBar";
+import useBreakpoint from "hooks/useBreakpoint";
+import WidgetContainer from "views/Dashboard/components/WidgetContainer";
 
 const Transactions: React.FC = () => {
+  const [drawerIsOpen, setDrawerIsOpen] = useState<boolean>(true);
+  const isMobileLarge = useBreakpoint("<", "lg");
+  const isMobileSmall = useBreakpoint("<", "sm");
+  const gridSize = isMobileLarge ? 12 : 6; // switch from double-column to single-column for smaller screens
+
+  const handleDrawerToggle = useCallback(() => {
+    setDrawerIsOpen((prev: boolean) => !prev);
+  }, []);
+
+  // sets the drawer state when the mobile breakpoint is hit
+  useEffect(() => {
+    if (isMobileSmall) {
+      setDrawerIsOpen(false);
+      return;
+    }
+    setDrawerIsOpen(true);
+  }, [isMobileSmall]);
+
   return (
     <Page>
-      {/* True temporarily pased in here, eventually Drawer will be hoisted to the <Page> level */}
-      <Drawer isSidebarExpanded={true} />
-      <SearchBar />
-      <Typography>Placeholder for the full Transactions page, coming soon.</Typography>
+      <WidgetContainer isSidebarExpanded={drawerIsOpen}>
+        {/* True temporarily pased in here, eventually Drawer will be hoisted to the <Page> level */}
+        <Drawer isSidebarExpanded={true} />
+        <SearchBar />
+        <Typography>Placeholder for the full Transactions page, coming soon.</Typography>
+      </WidgetContainer>
     </Page>
   );
 };

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -1,9 +1,11 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "@mui/material";
 import WidgetContainer from "views/Dashboard/components/WidgetContainer";
 import Page from "components/Page";
 import Drawer from "../../components/Drawer";
 import JUPAppBar from "components/JUPAppBar";
 import JUPTable, { IHeadCellProps, ITableRow } from "components/JUPTable";
+import JUPDialog from "components/JUPDialog";
 import { LongUnitPrecision } from "utils/common/constants";
 import { TimestampToDate } from "utils/common/Formatters";
 import { NQTtoNXT } from "utils/common/NQTtoNXT";
@@ -11,8 +13,6 @@ import useMyTxs from "hooks/useMyTxs";
 import useBreakpoint from "hooks/useBreakpoint";
 import { BigNumber } from "bignumber.js";
 import { ITransaction } from "types/NXTAPI";
-import { Link } from "@mui/material";
-import JUPDialog from "components/JUPDialog";
 
 const txOverviewHeaders: Array<IHeadCellProps> = [
   {

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -53,7 +53,7 @@ const Transactions: React.FC = () => {
         date: transaction.timestamp,
         date_ui: <Link onClick={() => handleOpenTxDetail(transaction.fullHash)}>{TimestampToDate(transaction.timestamp)}</Link>,
         qty: NQTtoNXT(new BigNumber(transaction.amountNQT)).toFixed(LongUnitPrecision),
-        fee: transaction.feeNQT,
+        fee: NQTtoNXT(new BigNumber(transaction.feeNQT)).toFixed(LongUnitPrecision),
         from: transaction.senderRS,
         to: transaction.recipientRS,
         height: transaction.height,

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -163,6 +163,7 @@ const Transactions: React.FC = () => {
           rows={txRows}
           defaultSortOrder="asc"
           keyProp={"fullHash"}
+          rowsPerPageStyle="long"
           isPaginated
         />
       </WidgetContainer>

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -1,37 +1,113 @@
-import React, { memo, useCallback, useEffect, useState } from "react";
-import { Typography } from "@mui/material";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import WidgetContainer from "views/Dashboard/components/WidgetContainer";
 import Page from "components/Page";
 import Drawer from "../../components/Drawer";
-import SearchBar from "components/SearchBar";
+import JUPAppBar from "components/JUPAppBar";
+import JUPTable, { IHeadCellProps, ITableRow } from "components/JUPTable";
+import { LongUnitPrecision } from "utils/common/constants";
+import { TimestampToDate } from "utils/common/Formatters";
+import { NQTtoNXT } from "utils/common/NQTtoNXT";
+import useMyTxs from "hooks/useMyTxs";
 import useBreakpoint from "hooks/useBreakpoint";
-import WidgetContainer from "views/Dashboard/components/WidgetContainer";
+import { BigNumber } from "bignumber.js";
+import { ITransaction } from "types/NXTAPI";
+
+const headCells: Array<IHeadCellProps> = [
+  {
+    id: "date",
+    label: "Date",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "qty",
+    label: "Qty",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "fee",
+    label: "Fee",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "from",
+    label: "From",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "to",
+    label: "To",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "height",
+    label: "Height",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "confirmations",
+    label: "Confirmations",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+];
 
 const Transactions: React.FC = () => {
   const [drawerIsOpen, setDrawerIsOpen] = useState<boolean>(true);
-  const isMobileLarge = useBreakpoint("<", "lg");
-  const isMobileSmall = useBreakpoint("<", "sm");
-  const gridSize = isMobileLarge ? 12 : 6; // switch from double-column to single-column for smaller screens
+  const isMobileMedium = useBreakpoint("<", "md");
+  const { transactions } = useMyTxs();
 
   const handleDrawerToggle = useCallback(() => {
     setDrawerIsOpen((prev: boolean) => !prev);
   }, []);
 
+  const txRows: Array<ITableRow> | undefined = useMemo(() => {
+    if (transactions === undefined || !Array.isArray(transactions)) {
+      return undefined;
+    }
+
+    return transactions.map((transaction: ITransaction) => {
+      return {
+        fullHash: transaction.fullHash,
+        date: TimestampToDate(transaction.timestamp),
+        qty: NQTtoNXT(new BigNumber(transaction.amountNQT)).toFixed(LongUnitPrecision),
+        fee: transaction.feeNQT,
+        from: transaction.senderRS,
+        to: transaction.recipientRS,
+        height: transaction.height,
+        confirmations: transaction.confirmations,
+      };
+    });
+  }, [transactions]);
+
   // sets the drawer state when the mobile breakpoint is hit
   useEffect(() => {
-    if (isMobileSmall) {
+    if (isMobileMedium) {
       setDrawerIsOpen(false);
       return;
     }
     setDrawerIsOpen(true);
-  }, [isMobileSmall]);
+  }, [isMobileMedium]);
 
   return (
     <Page>
+      <Drawer isSidebarExpanded={drawerIsOpen} />
+      <JUPAppBar toggleFn={handleDrawerToggle} isSidebarExpanded={drawerIsOpen} />
       <WidgetContainer isSidebarExpanded={drawerIsOpen}>
-        {/* True temporarily pased in here, eventually Drawer will be hoisted to the <Page> level */}
-        <Drawer isSidebarExpanded={true} />
-        <SearchBar />
-        <Typography>Placeholder for the full Transactions page, coming soon.</Typography>
+        <JUPTable
+          title={"My Transactions"}
+          path={"/transactions"}
+          headCells={headCells}
+          rows={txRows}
+          defaultSortOrder="asc"
+          keyProp={"fullHash"}
+          isPaginated
+        />
       </WidgetContainer>
     </Page>
   );

--- a/src/views/Transactions/constants/detailedTxColumns.tsx
+++ b/src/views/Transactions/constants/detailedTxColumns.tsx
@@ -1,5 +1,8 @@
 import { IHeadCellProps, ITableRow } from "components/JUPTable";
 import { ITransaction } from "types/NXTAPI";
+import { BigNumber } from "bignumber.js";
+import { LongUnitPrecision } from "utils/common/constants";
+import { NQTtoNXT } from "utils/common/NQTtoNXT";
 
 export interface ITxDetail {
   txId: string; // the numerical version of the tx, not a hash
@@ -51,7 +54,7 @@ export const detailedTxColumns = (tx: ITransaction) => {
       },
       {
         col1: "Fee",
-        col2: tx?.feeNQT,
+        col2: NQTtoNXT(new BigNumber(tx?.feeNQT)).toFixed(LongUnitPrecision),
       },
       {
         col1: "Recipient Id",

--- a/src/views/Transactions/constants/detailedTxColumns.tsx
+++ b/src/views/Transactions/constants/detailedTxColumns.tsx
@@ -1,0 +1,78 @@
+import { IHeadCellProps, ITableRow } from "components/JUPTable";
+import { ITransaction } from "types/NXTAPI";
+
+export interface ITxDetail {
+  txId: string; // the numerical version of the tx, not a hash
+  headers: Array<IHeadCellProps>;
+  rows: Array<ITableRow>;
+}
+
+export const detailedTxColumns = (tx: ITransaction) => {
+  return {
+    txId: tx?.transaction,
+    headers: [
+      {
+        id: "col1",
+        label: "Name",
+        headAlignment: "center",
+        rowAlignment: "center",
+      },
+      {
+        id: "col2",
+        label: "Details",
+        headAlignment: "center",
+        rowAlignment: "center",
+      },
+    ],
+    rows: [
+      {
+        col1: "Hash",
+        col2: tx.fullHash,
+      },
+      {
+        col1: "Value",
+        col2: tx?.amountNQT,
+      },
+      {
+        col1: "Tx Attachment",
+        col2: JSON.stringify(tx?.attachment),
+      },
+      {
+        col1: "Block Id",
+        col2: tx?.block,
+      },
+      {
+        col1: "Block Height",
+        col2: tx?.height,
+      },
+      {
+        col1: "Confirmations",
+        col2: tx?.confirmations,
+      },
+      {
+        col1: "Fee",
+        col2: tx?.feeNQT,
+      },
+      {
+        col1: "Recipient Id",
+        col2: tx?.recipient,
+      },
+      {
+        col1: "Recipient Address",
+        col2: tx?.recipientRS,
+      },
+      {
+        col1: "Sender Id",
+        col2: tx?.sender,
+      },
+      {
+        col1: "Sender Address",
+        col2: tx?.senderRS,
+      },
+      {
+        col1: "Sender Public Key",
+        col2: tx?.senderPublicKey,
+      },
+    ],
+  } as ITxDetail;
+};

--- a/src/views/Transactions/constants/txOverviewHeaders.tsx
+++ b/src/views/Transactions/constants/txOverviewHeaders.tsx
@@ -1,0 +1,46 @@
+import { IHeadCellProps } from "components/JUPTable";
+
+export const txOverviewHeaders: Array<IHeadCellProps> = [
+  {
+    id: "date_ui",
+    label: "Date",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "qty",
+    label: "Qty",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "fee",
+    label: "Fee",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "from",
+    label: "From",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "to",
+    label: "To",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "height",
+    label: "Height",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+  {
+    id: "confirmations",
+    label: "Confirmations",
+    headAlignment: "center",
+    rowAlignment: "center",
+  },
+];


### PR DESCRIPTION
Adds a transactions view / full page app.

Still needs a couple of things:

- [x] Improve pagination, maybe by passing in an array of pagination qty options instead of having them baked into the JUPTable. Another option would be setting a flag for "isWidget" which could supply one set of pagination options, but this would be less flexible overall.
- [x] Make the date column clickable so full tx details can be provided in a dialog, like block heights for the blocks widget