### PR TITLE
Add comma separators to displayed values

### DIFF
--- a/src/components/CollapsingPortfolioTable/CollapsingPortfolioTable.tsx
+++ b/src/components/CollapsingPortfolioTable/CollapsingPortfolioTable.tsx
@@ -21,6 +21,7 @@ import AssetActionsStack from "components/AssetActionsStack";
 import JUPInput from "components/JUPInput";
 import { LedaNFTName } from "utils/common/constants";
 import { messageText } from "utils/common/messages";
+import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAssets from "hooks/useAssets";
 import useAPIRouter from "hooks/useAPIRouter";
 import { useSnackbar } from "notistack";
@@ -175,7 +176,7 @@ const CollapsingPortfolioTable: React.FC = () => {
       return createData({
         name: asset.assetDetails.name,
         description: asset.assetDetails.description,
-        qtyOwned: asset.quantityQNT,
+        qtyOwned: addCommaSeparators(asset.quantityQNT),
         assetActions: (
           <AssetActionsStack
             handleSendAsset={handleSendAsset}
@@ -269,7 +270,7 @@ function createData({ name, description, qtyOwned, assetActions, assetDetails }:
         name: assetDetails.name,
         description: assetDetails.description,
         decimals: assetDetails.decimals,
-        quantityQNT: assetDetails.quantityQNT,
+        quantityQNT: addCommaSeparators(assetDetails.quantityQNT),
       },
     ],
   };

--- a/src/components/SearchBar/components/BlockheightChip/BlockheightChip.tsx
+++ b/src/components/SearchBar/components/BlockheightChip/BlockheightChip.tsx
@@ -2,12 +2,13 @@ import React, { memo } from "react";
 import { Chip, styled } from "@mui/material";
 import useBlocks from "hooks/useBlocks";
 import useBreakpoint from "hooks/useBreakpoint";
+import { addCommaSeparators } from "utils/common/addCommaSeparators";
 
 const BlockheightChip: React.FC = () => {
   const { blockHeight } = useBlocks();
   const isMobileMedium = useBreakpoint("<", "md");
 
-  return <StyledChip color="primary" label={isMobileMedium ? blockHeight : "Height: " + blockHeight} />;
+  return <StyledChip color="primary" label={isMobileMedium ? blockHeight : "Height: " + addCommaSeparators(blockHeight)} />;
 };
 
 const StyledChip = styled(Chip)(() => ({

--- a/src/utils/common/NQTtoNXT.ts
+++ b/src/utils/common/NQTtoNXT.ts
@@ -5,8 +5,9 @@
 //
 
 import { BigNumber } from "bignumber.js";
+import { addCommaSeparators } from "./addCommaSeparators";
 import { PrecisionExponent } from "./constants";
 
 export function NQTtoNXT(quantity: BigNumber, precision: number): string {
-  return new BigNumber(quantity).dividedBy(10 ** PrecisionExponent).toFixed(precision);
+  return addCommaSeparators(new BigNumber(quantity).dividedBy(10 ** PrecisionExponent).toFixed(precision));
 }

--- a/src/utils/common/addCommaSeparators.ts
+++ b/src/utils/common/addCommaSeparators.ts
@@ -1,0 +1,18 @@
+//
+// simple utility for adding comma separators to numbers and strings
+//
+
+import { BigNumber } from "bignumber.js";
+
+export const addCommaSeparators = (inputVal: string | number | undefined): string => {
+  if (inputVal === undefined) {
+    return "-";
+  }
+
+  // if a passed value is a string we want to use the bignumbers library to convert it to a number so it will have the required toLocaleString() method
+  if (typeof inputVal === "string") {
+    inputVal = new BigNumber(inputVal).toNumber();
+  }
+
+  return inputVal ? inputVal.toLocaleString() : "0";
+};

--- a/src/views/DEX/DEX.tsx
+++ b/src/views/DEX/DEX.tsx
@@ -5,6 +5,7 @@ import JUPInput from "components/JUPInput";
 import HistoryContainer from "./components/HistoryContainer/HistoryContainer";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { defaultAssetList } from "utils/common/defaultAssets";
+import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAPI from "hooks/useAPI";
 import { IAsset } from "types/NXTAPI";
 import OrderBook from "./components/OrderBook";
@@ -103,7 +104,7 @@ const DEX: React.FC = () => {
         <Typography>Name: {assetDetails?.name}</Typography>
         <Typography>Asset ID: {assetDetails?.asset}</Typography>
         <Typography>
-          Circulating: {assetDetails?.quantityQNT} {assetDetails?.name}
+          Circulating: {addCommaSeparators(assetDetails?.quantityQNT)} {assetDetails?.name}
         </Typography>
         <Typography>Decimals: {assetDetails?.decimals}</Typography>
         <Link>Show Distribution</Link>

--- a/src/views/Dashboard/components/Widgets/BlocksWidget/BlocksWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/BlocksWidget/BlocksWidget.tsx
@@ -11,6 +11,7 @@ import { txDetailHeaders } from "./constants/txDetailHeaders";
 import { getBlockDetailHeaders, IBlockDetail } from "./constants/blockDetailHeaders";
 import { useSnackbar } from "notistack";
 import { messageText } from "utils/common/messages";
+import { addCommaSeparators } from "utils/common/addCommaSeparators";
 
 interface ITransactionDetail {
   headers: Array<IHeadCellProps>;
@@ -84,7 +85,7 @@ const BlocksWidget: React.FC<IBlocksWidgetProps> = ({ disableDisplayComponents }
         date: TimestampToDate(block.timestamp),
         blockHeight_ui: <Link onClick={() => handleOpenBlockDetail(block.height)}>{block.height}</Link>,
         txCount: block.numberOfTransactions.toString(),
-        value: block.totalAmountNQT,
+        value: addCommaSeparators(block.totalAmountNQT),
         generator: block.generatorRS,
         // TODO: move to constants, this value fixes an upstream calculation bug in the base target values
         baseTarget: Math.round(parseInt(block.baseTarget) / 153722867 / 10) + " %",

--- a/src/views/Dashboard/components/Widgets/PortfolioWidget/PortfolioWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/PortfolioWidget/PortfolioWidget.tsx
@@ -5,6 +5,7 @@ import JUPDialog from "components/JUPDialog";
 import JUPInput from "components/JUPInput";
 import { LedaNFTName } from "utils/common/constants";
 import { messageText } from "utils/common/messages";
+import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAssets from "hooks/useAssets";
 import useAPIRouter from "hooks/useAPIRouter";
 import { useSnackbar } from "notistack";
@@ -119,7 +120,7 @@ const PortfolioWidget: React.FC = () => {
       return {
         assetId: asset.asset,
         assetName: asset.assetDetails.name,
-        assetBalance: asset.quantityQNT,
+        assetBalance: addCommaSeparators(asset.quantityQNT),
         assetDescription: asset.assetDetails.description,
         actions: (
           <AssetActionsStack

--- a/src/views/Generators/Generators.tsx
+++ b/src/views/Generators/Generators.tsx
@@ -8,6 +8,7 @@ import { generatorOverviewHeaders } from "./constants/generatorOverviewHeaders";
 import { isPollingFrequencyMet } from "utils/common/isPollingFrequencyMet";
 import { GeneratorPollingFrequency } from "utils/common/constants";
 import { TimestampToDate } from "utils/common/Formatters";
+import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAPI from "hooks/useAPI";
 
 const Generators: React.FC = () => {
@@ -23,7 +24,7 @@ const Generators: React.FC = () => {
     return generators.map((generator: IGenerator) => {
       return {
         account: generator.accountRS,
-        effectiveBalance: `${generator.effectiveBalanceNXT.toLocaleString()} JUP`,
+        effectiveBalance: `${addCommaSeparators(generator.effectiveBalanceNXT)} JUP`,
         hitTime: TimestampToDate(generator.hitTime),
         deadline: generator.deadline,
       };


### PR DESCRIPTION
Closes #142 by adding comma separators for thousands values. Uses `toLocaleString()` so it should support different regions better since there are different comma and decimal formats globally. 


