### PR TITLE
Wrap JUP Tables on 500px maxWidth

### DIFF
--- a/src/components/JUPTable/JUPTable.tsx
+++ b/src/components/JUPTable/JUPTable.tsx
@@ -157,7 +157,11 @@ const JUPTable: React.FC<IJUPTableProps> = ({
       ?.map((row, index) => {
         const cells = headCells?.map((headCell, headIndex) => {
           return (
-            <TableCell sx={{ whiteSpace: "nowrap" }} align={headCell.rowAlignment} key={`tc-${row[headCell.id]}-${index}-${headIndex}`}>
+            <TableCell
+              sx={{ whiteSpace: "normal", maxWidth: "500px", wordWrap: "break-word" }}
+              align={headCell.rowAlignment}
+              key={`tc-${row[headCell.id]}-${index}-${headIndex}`}
+            >
               {row[headCell.id]}
             </TableCell>
           );


### PR DESCRIPTION
Closes #141 

This addresses the description text being very wide and addresses transaction data in the block detail window as a bonus.