### PR TITLE
Beta 0.0.2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,3 +7,4 @@
 ## 0.0.2
 
 - Fix addCommaSeparators() so it can handle values < 1
+- Fix blockWidget display precision and sendWidget sending precision

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,3 +3,7 @@
 ## 0.0.1
 
 - Initial Beta test release version. This will be incremented as beta is updated, and release notes will start from this point forward.
+
+## 0.0.2
+
+- Fix addCommaSeparators() so it can handle values < 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupiter-wallet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "proxy": "node proxy/server.js",

--- a/src/utils/common/NXTtoNQT.ts
+++ b/src/utils/common/NXTtoNQT.ts
@@ -5,7 +5,8 @@
 //
 
 import { BigNumber } from "bignumber.js";
+import { PrecisionExponent } from "./constants";
 
 export function NXTtoNQT(quantity: BigNumber): BigNumber {
-  return new BigNumber(quantity.pow(8));
+  return new BigNumber(quantity.multipliedBy(10 ** PrecisionExponent));
 }

--- a/src/utils/common/addCommaSeparators.ts
+++ b/src/utils/common/addCommaSeparators.ts
@@ -9,6 +9,10 @@ export const addCommaSeparators = (inputVal: string | number | undefined): strin
     return "-";
   }
 
+  if (inputVal < 1) {
+    return inputVal.toString();
+  }
+
   // if a passed value is a string we want to use the bignumbers library to convert it to a number so it will have the required toLocaleString() method
   if (typeof inputVal === "string") {
     inputVal = new BigNumber(inputVal).toNumber();

--- a/src/views/Dashboard/components/Widgets/BlocksWidget/BlocksWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/BlocksWidget/BlocksWidget.tsx
@@ -12,6 +12,9 @@ import { getBlockDetailHeaders, IBlockDetail } from "./constants/blockDetailHead
 import { useSnackbar } from "notistack";
 import { messageText } from "utils/common/messages";
 import { addCommaSeparators } from "utils/common/addCommaSeparators";
+import { NQTtoNXT } from "utils/common/NQTtoNXT";
+import { LongUnitPrecision } from "utils/common/constants";
+import { BigNumber } from "bignumber.js";
 
 interface ITransactionDetail {
   headers: Array<IHeadCellProps>;
@@ -85,7 +88,7 @@ const BlocksWidget: React.FC<IBlocksWidgetProps> = ({ disableDisplayComponents }
         date: TimestampToDate(block.timestamp),
         blockHeight_ui: <Link onClick={() => handleOpenBlockDetail(block.height)}>{block.height}</Link>,
         txCount: block.numberOfTransactions.toString(),
-        value: addCommaSeparators(block.totalAmountNQT),
+        value: addCommaSeparators(NQTtoNXT(new BigNumber(block.totalAmountNQT), LongUnitPrecision)),
         generator: block.generatorRS,
         // TODO: move to constants, this value fixes an upstream calculation bug in the base target values
         baseTarget: Math.round(parseInt(block.baseTarget) / 153722867 / 10) + " %",

--- a/src/views/Dashboard/components/Widgets/SendWidget/SendWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/SendWidget/SendWidget.tsx
@@ -2,6 +2,8 @@ import React, { memo, useCallback, useMemo, useState } from "react";
 import { Button, Checkbox, Grid, InputLabel, Stack, styled, Typography } from "@mui/material";
 import useAPIRouter from "hooks/useAPIRouter";
 import JUPInput from "components/JUPInput";
+import { NXTtoNQT } from "utils/common/NXTtoNQT";
+import { BigNumber } from "bignumber.js";
 
 const SendWidget: React.FC = () => {
   const [toAddress, setToAddress] = useState<string>();
@@ -14,7 +16,8 @@ const SendWidget: React.FC = () => {
       return;
     }
 
-    const result = await sendJUP(toAddress, sendQuantity, isMessageIncluded);
+    // convert the user's input value to NQT value like the send API requires
+    const result = await sendJUP(toAddress, NXTtoNQT(new BigNumber(sendQuantity)).toString(), isMessageIncluded);
 
     if (!result) {
       console.error("unable to sendJup");


### PR DESCRIPTION
Fixes addCommaSeparators() so it works with values < 1 (was previously returning "0" for these values). 

Also fixes a display precision issue in the blocksWidget and a precision issue when sending jup from the sendWidget where sending 100 JUP actually sent 0.00000100 JUP