### PR TITLE
Remove My Account option from gear/settings menu 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,3 +8,7 @@
 
 - Fix addCommaSeparators() so it can handle values < 1
 - Fix blockWidget display precision and sendWidget sending precision
+
+## 0.0.3
+
+- Remove My Accounts from gear menu

--- a/src/components/JUPSettingsMenu/JUPSettingsMenu.tsx
+++ b/src/components/JUPSettingsMenu/JUPSettingsMenu.tsx
@@ -73,10 +73,6 @@ const JUPSettingsMenu: React.FC = () => {
         }}
       >
         <MenuItem>
-          <Avatar /> My account
-        </MenuItem>
-        <Divider />
-        <MenuItem>
           <ListItemIcon>
             <Settings fontSize="small" />
           </ListItemIcon>


### PR DESCRIPTION
This was supposed to be removed earlier since the use case is already covered from the user details section.