### PR TITLE
Display generator page's last block time in 24 hour time format

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,3 +8,7 @@
 
 - Fix addCommaSeparators() so it can handle values < 1
 - Fix blockWidget display precision and sendWidget sending precision
+
+## 0.0.3
+
+- Displays the last block time on the Generators page in 24hr time format instead of 12hr

--- a/src/views/Generators/Generators.tsx
+++ b/src/views/Generators/Generators.tsx
@@ -47,7 +47,7 @@ const Generators: React.FC = () => {
   return (
     <Page>
       <MetricsGroup
-        lastBlockTime={latestBlocktime ? new Date(latestBlocktime).toLocaleTimeString() : "-"}
+        lastBlockTime={latestBlocktime ? new Date(latestBlocktime).toLocaleTimeString(undefined, { hour12: false }) : "-"}
         currentHeight={blockHeight ? blockHeight.toString() : "-"}
         activeForgers={generators ? generators.length.toString() : "-"}
       />


### PR DESCRIPTION
As suggested during Beta. This cleans up the metric display, reducing it to a single line and clearing up any AM/PM confusion users might have. 