### PR TITLE
Fix Various Asset Balance Quantity Issues

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,3 +14,7 @@
 - Add ability to send JUP directly from the address book component
 - Displays the last block time on the Generators page in 24hr time format instead of 12hr
 - Remove My Accounts from gear menu
+
+## 0.0.4
+
+- Fix asset precision/quantity issue by properly converting assets with different decimals params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupiter-wallet",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "proxy": "node proxy/server.js",

--- a/src/components/CollapsingPortfolioTable/CollapsingPortfolioTable.tsx
+++ b/src/components/CollapsingPortfolioTable/CollapsingPortfolioTable.tsx
@@ -19,12 +19,13 @@ import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import JUPDialog from "components/JUPDialog";
 import AssetActionsStack from "components/AssetActionsStack";
 import JUPInput from "components/JUPInput";
-import { LedaNFTName } from "utils/common/constants";
+import { LedaNFTName, LongUnitPrecision } from "utils/common/constants";
 import { messageText } from "utils/common/messages";
-import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAssets from "hooks/useAssets";
 import useAPIRouter from "hooks/useAPIRouter";
 import { useSnackbar } from "notistack";
+import { QNTtoNXT } from "utils/common/QNTtoNXT";
+import { BigNumber } from "bignumber.js";
 
 interface IPortfolioAssets {
   name: string;
@@ -176,7 +177,7 @@ const CollapsingPortfolioTable: React.FC = () => {
       return createData({
         name: asset.assetDetails.name,
         description: asset.assetDetails.description,
-        qtyOwned: addCommaSeparators(asset.quantityQNT),
+        qtyOwned: asset.quantityQNT,
         assetActions: (
           <AssetActionsStack
             handleSendAsset={handleSendAsset}
@@ -189,7 +190,7 @@ const CollapsingPortfolioTable: React.FC = () => {
           name: asset.assetDetails.name,
           description: asset.assetDetails.description,
           decimals: asset.assetDetails.decimals,
-          quantityQNT: `${asset.assetDetails.quantityQNT}`,
+          quantityQNT: asset.assetDetails.quantityQNT,
         },
       });
     });
@@ -263,14 +264,14 @@ function createData({ name, description, qtyOwned, assetActions, assetDetails }:
   return {
     name,
     description,
-    qtyOwned,
+    qtyOwned: QNTtoNXT(new BigNumber(qtyOwned), assetDetails.decimals, LongUnitPrecision),
     assetActions,
     assetDetails: [
       {
         name: assetDetails.name,
         description: assetDetails.description,
         decimals: assetDetails.decimals,
-        quantityQNT: addCommaSeparators(assetDetails.quantityQNT),
+        quantityQNT: assetDetails.quantityQNT,
       },
     ],
   };

--- a/src/utils/common/QNTtoNXT.ts
+++ b/src/utils/common/QNTtoNXT.ts
@@ -1,0 +1,12 @@
+//
+// Basic converter to handle the QNT balances returned from the API, for assets
+//
+// Docs: https://nxtdocs.jelurida.com/API#Quantity_Units_NXT.2C_NQT_and_QNT
+//
+
+import { BigNumber } from "bignumber.js";
+import { addCommaSeparators } from "./addCommaSeparators";
+
+export function QNTtoNXT(quantity: BigNumber, decimals: number, precision: number): string {
+  return addCommaSeparators(new BigNumber(quantity).dividedBy(10 ** decimals).toFixed(precision));
+}

--- a/src/views/DEX/DEX.tsx
+++ b/src/views/DEX/DEX.tsx
@@ -5,13 +5,14 @@ import JUPInput from "components/JUPInput";
 import HistoryContainer from "./components/HistoryContainer/HistoryContainer";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import { defaultAssetList } from "utils/common/defaultAssets";
-import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAPI from "hooks/useAPI";
 import { IAsset } from "types/NXTAPI";
 import OrderBook from "./components/OrderBook";
 import InfoIcon from "@mui/icons-material/Info";
 import useAPIRouter from "hooks/useAPIRouter";
 import { BigNumber } from "bignumber.js";
+import { LongUnitPrecision } from "utils/common/constants";
+import { QNTtoNXT } from "utils/common/QNTtoNXT";
 
 // TODO:
 //  [ ] Paginate swaps tables
@@ -104,7 +105,7 @@ const DEX: React.FC = () => {
         <Typography>Name: {assetDetails?.name}</Typography>
         <Typography>Asset ID: {assetDetails?.asset}</Typography>
         <Typography>
-          Circulating: {addCommaSeparators(assetDetails?.quantityQNT)} {assetDetails?.name}
+          Circulating: {QNTtoNXT(new BigNumber(assetDetails?.quantityQNT), assetDetails.decimals, LongUnitPrecision)} {assetDetails?.name}
         </Typography>
         <Typography>Decimals: {assetDetails?.decimals}</Typography>
         <Link>Show Distribution</Link>

--- a/src/views/Dashboard/components/Widgets/PortfolioWidget/PortfolioWidget.tsx
+++ b/src/views/Dashboard/components/Widgets/PortfolioWidget/PortfolioWidget.tsx
@@ -3,13 +3,14 @@ import { Button, Stack } from "@mui/material";
 import JUPTable, { IHeadCellProps, ITableRow } from "components/JUPTable";
 import JUPDialog from "components/JUPDialog";
 import JUPInput from "components/JUPInput";
-import { LedaNFTName } from "utils/common/constants";
+import { LedaNFTName, LongUnitPrecision } from "utils/common/constants";
 import { messageText } from "utils/common/messages";
-import { addCommaSeparators } from "utils/common/addCommaSeparators";
 import useAssets from "hooks/useAssets";
 import useAPIRouter from "hooks/useAPIRouter";
 import { useSnackbar } from "notistack";
 import AssetActionsStack from "components/AssetActionsStack";
+import { QNTtoNXT } from "utils/common/QNTtoNXT";
+import { BigNumber } from "bignumber.js";
 
 const headCells: Array<IHeadCellProps> = [
   {
@@ -120,7 +121,7 @@ const PortfolioWidget: React.FC = () => {
       return {
         assetId: asset.asset,
         assetName: asset.assetDetails.name,
-        assetBalance: addCommaSeparators(asset.quantityQNT),
+        assetBalance: QNTtoNXT(new BigNumber(asset.quantityQNT), asset.assetDetails.decimals, LongUnitPrecision),
         assetDescription: asset.assetDetails.description,
         actions: (
           <AssetActionsStack


### PR DESCRIPTION
Closes #177 

When originally written it was unknown that an asset's `decimals` factored into their QNT conversion rate. This PR fixes this by creating `QNTToNXT()` which takes in the `decimals` and uses it in several areas where needed. 